### PR TITLE
Added types export to package.json exports field

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "main": "dist/plimit-lit.cjs",
   "module": "dist/plimit-lit.module.js",
   "exports": {
+    "types": "./dist/index.d.ts",
     "require": "./dist/plimit-lit.cjs",
     "import": "./dist/plimit-lit.modern.js"
   },


### PR DESCRIPTION
typescript can't find types when using typescript moduleResolution Node16 or NodeNext, because it needs the link to the file in the exports field.