### PR TITLE
Removed engine requirements

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,9 +12,6 @@
     "type": "git",
     "url": "git+https://github.com/joelvoss/plimit-lit.git"
   },
-  "engines": {
-    "node": ">=18"
-  },
   "type": "module",
   "source": "src/index.js",
   "main": "dist/plimit-lit.cjs",


### PR DESCRIPTION
Our pipeline uses node 16. This engine requirement broke our build. Removing this engine requirement because the packages that changed in release 1.6.0 doesn't seem to require node 18. The README also says that this package supports node v12+. That's no longer the case with the 1.6.0 update.

If this engine requirement is still necessary, I recommend that we revert the 1.6.0 changes and then upgrade the major version of this package instead. The engine requirement is a breaking change.
